### PR TITLE
Use new MiddlewareHandler typing requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@remix-run/server-runtime": "^1.19.1",
-				"hono": "^3.3.3",
+				"hono": "^3.6.1",
 				"pretty-cache-header": "^1.0.0"
 			},
 			"devDependencies": {
@@ -3277,9 +3277,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-3.6.0.tgz",
-			"integrity": "sha512-snkW8naO1WCrQvpAGE/du30Ek0h71gSM3g4RzzdPIB2LQnl12BEwZYH3s2Kssd6kXGORqHmpoyMBMLWtc9nzKQ==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-3.6.1.tgz",
+			"integrity": "sha512-FaWXh0MSc2Hv2IrGI4vFvZEK69NHfggEgHUlNMXp2zrpKh23j7wS0Ku316Do9CFAl07OBNozBelcvruiBT8crQ==",
 			"engines": {
 				"node": ">=16.0.0"
 			}
@@ -8309,9 +8309,9 @@
 			}
 		},
 		"hono": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-3.6.0.tgz",
-			"integrity": "sha512-snkW8naO1WCrQvpAGE/du30Ek0h71gSM3g4RzzdPIB2LQnl12BEwZYH3s2Kssd6kXGORqHmpoyMBMLWtc9nzKQ=="
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-3.6.1.tgz",
+			"integrity": "sha512-FaWXh0MSc2Hv2IrGI4vFvZEK69NHfggEgHUlNMXp2zrpKh23j7wS0Ku316Do9CFAl07OBNozBelcvruiBT8crQ=="
 		},
 		"hosted-git-info": {
 			"version": "2.8.9",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 	},
 	"dependencies": {
 		"@remix-run/server-runtime": "^1.19.1",
-		"hono": "^3.3.3",
+		"hono": "^3.6.1",
 		"pretty-cache-header": "^1.0.0"
 	},
 	"optionalDependencies": {

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -1,4 +1,4 @@
-import type { Context, MiddlewareHandler } from "hono";
+import type { Context, Env, Input, MiddlewareHandler } from "hono";
 
 import {
 	CookieOptions,
@@ -14,11 +14,13 @@ interface StaticAssetsOptions {
 	cache?: Parameters<typeof cacheHeader>[0];
 }
 
-export function staticAssets(
-	options: StaticAssetsOptions = {},
-): MiddlewareHandler {
+export function staticAssets<
+	E extends Env = Record<string, never>,
+	P extends string = "",
+	I extends Input = Record<string, never>,
+>(options: StaticAssetsOptions = {}): MiddlewareHandler<E, P, I> {
 	return async function staticAssets(ctx, next) {
-		let binding = ctx.env.ASSETS as Fetcher | undefined;
+		let binding = ctx.env?.ASSETS as Fetcher | undefined;
 
 		if (!binding) throw new ReferenceError("The binding ASSETS is not set.");
 
@@ -67,7 +69,9 @@ export function workerKVSession<
 		secrets: GetWorkerKVSecretsFunction<KVBinding, SecretBinding>;
 	};
 	binding: KVBinding;
-}): MiddlewareHandler {
+}): MiddlewareHandler<{
+	Bindings: WorkerKVBindingsObject<KVBinding, SecretBinding>;
+}> {
 	return session<
 		{ Bindings: WorkerKVBindingsObject<KVBinding, SecretBinding> },
 		"",
@@ -114,7 +118,7 @@ export function cookieSession<
 		name: string;
 		secrets: GetCookieSecretsFunction<SecretBinding>;
 	};
-}): MiddlewareHandler {
+}): MiddlewareHandler<{ Bindings: CookieBindingsObject<SecretBinding> }> {
 	return session<
 		{ Bindings: CookieBindingsObject<SecretBinding> },
 		"",

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -23,7 +23,7 @@ export function remix<
 	mode,
 	build,
 	getLoadContext = (context) => context.env as unknown as AppLoadContext,
-}: RemixMiddlewareOptions<E, P, I>): MiddlewareHandler {
+}: RemixMiddlewareOptions<E, P, I>): MiddlewareHandler<E, P, I> {
 	return async function middleware(context) {
 		let requestHandler = createRequestHandler(build, mode);
 		let loadContext = getLoadContext(context);

--- a/src/i18next.ts
+++ b/src/i18next.ts
@@ -1,4 +1,4 @@
-import type { Context, MiddlewareHandler } from "hono";
+import type { Context, Env, Input, MiddlewareHandler } from "hono";
 import type { RemixI18NextOption } from "remix-i18next";
 
 import { Namespace, TFunction } from "i18next";
@@ -8,9 +8,11 @@ const i18nSymbol = Symbol();
 const LocaleSymbol = Symbol();
 const TSymbol = Symbol();
 
-export function i18next(
-	options: RemixI18NextOption | RemixI18Next,
-): MiddlewareHandler {
+export function i18next<
+	E extends Env = Record<string, never>,
+	P extends string = "",
+	I extends Input = Record<string, never>,
+>(options: RemixI18NextOption | RemixI18Next): MiddlewareHandler<E, P, I> {
 	return async function middleware(ctx, next) {
 		let i18n =
 			options instanceof RemixI18Next ? options : new RemixI18Next(options);
@@ -19,9 +21,12 @@ export function i18next(
 
 		let t = await i18n.getFixedT(locale);
 
-		ctx.set(i18nSymbol, i18n);
-		ctx.set(LocaleSymbol, locale);
-		ctx.set(TSymbol, t);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		ctx.set<any>(i18nSymbol, i18n);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		ctx.set<any>(LocaleSymbol, locale);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		ctx.set<any>(TSymbol, t);
 
 		await next();
 	};

--- a/src/session.ts
+++ b/src/session.ts
@@ -19,11 +19,12 @@ export function session<
 	createSessionStorage(
 		context: Context<E, P, I>,
 	): SessionStorage<Data, FlashData>;
-}): MiddlewareHandler {
+}): MiddlewareHandler<E, P, I> {
 	return async function middleware(context, next) {
 		let sessionStorage = options.createSessionStorage(context);
 
-		context.set(sessionStorageSymbol, sessionStorage);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		context.set<any>(sessionStorageSymbol, sessionStorage);
 
 		// If autoCommit is disabled, we just create the SessionStorage and make it
 		// available with context.get(sessionStorageSymbol), then call next() and
@@ -36,7 +37,8 @@ export function session<
 		);
 
 		// And make it available with context.get(sessionSymbol).
-		context.set(sessionSymbol, session);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		context.set<any>(sessionSymbol, session);
 
 		// Then we call next() to let the rest of the middlewares run.
 		await next();


### PR DESCRIPTION
Hello there,

Related to https://github.com/honojs/hono/pull/1449/files

I don't know if it's the best solution but it fixes the typing issues, still keeping code inference. 

`// eslint-disable-next-line @typescript-eslint/no-explicit-any` for `ctx.set<any>` seems legit, what do you think?