### PR TITLE
Support for multiple session middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,43 @@ server.use(
 In both `workerKVSession` and `cookieSession` you use `getSession` and
 `getSessionStorage` imported from `remix-hono/session`
 
+If you want to use multiple sessions, you can specify custom `sessionStorageKey` / `sessionKey`.
+
+```ts
+server.use(
+	"*",
+	cookieSession({
+		sessionStorageKey: "session-storage-1",
+		sessionKey: "session-1",
+		// ...
+	}),
+	workerKVSession({
+		sessionStorageKey: "session-storage-2",
+		sessionKey: "session-2",
+		// ...
+	}),
+	remix<ContextEnv>({
+		build,
+		mode: process.env.NODE_ENV as "development" | "production",
+		getLoadContext(c) {
+			let sessionStorage1 = getSessionStorage(c, "session-storage-1");
+			let session1 = getSession(c, "session-1");
+
+			let sessionStorage2 = getSessionStorage(c, "session-storage-2");
+			let session2 = getSession(c, "session-2");
+
+			return {
+				...c.env,
+				sessionStorage1,
+				session1,
+				sessionStorage2,
+				session2,
+			};
+		},
+	}),
+);
+```
+
 ## Static Assets on Cloudflare
 
 If you're using Remix Hono with Cloudflare, you will need to serve your static

--- a/src/cloudflare.ts
+++ b/src/cloudflare.ts
@@ -66,9 +66,13 @@ export function workerKVSession<
 		secrets: GetWorkerKVSecretsFunction<KVBinding, SecretBinding>;
 	};
 	binding: KVBinding;
+	sessionStorageKey?: PropertyKey;
+	sessionKey?: PropertyKey;
 }) {
 	return session<Data, FlashData>({
 		autoCommit: options.autoCommit,
+		sessionStorageKey: options.sessionStorageKey,
+		sessionKey: options.sessionKey,
 		createSessionStorage(c) {
 			if (!(options.binding in c.env)) {
 				throw new ReferenceError("The binding for the kvSession is not set.");
@@ -107,9 +111,13 @@ export function cookieSession<
 		name: string;
 		secrets: GetCookieSecretsFunction<SecretBinding>;
 	};
+	sessionStorageKey?: PropertyKey;
+	sessionKey?: PropertyKey;
 }) {
 	return session<Data, FlashData>({
 		autoCommit: options.autoCommit,
+		sessionStorageKey: options.sessionStorageKey,
+		sessionKey: options.sessionKey,
 		createSessionStorage(c) {
 			let secrets = options.cookie.secrets(c);
 

--- a/test/cloudflare.test.ts
+++ b/test/cloudflare.test.ts
@@ -214,6 +214,28 @@ describe("middleware", () => {
 				kv: "kv",
 			});
 		});
+
+		test("forwards sessionKey and sessionStorageKey", async () => {
+			workerKVSession<"KV_BINDING", "SECRET">({
+				autoCommit: true,
+				cookie: {
+					name: "session",
+					secrets(c) {
+						return [c.env.SECRET];
+					},
+				},
+				binding: "KV_BINDING",
+				sessionKey: "sessionKey",
+				sessionStorageKey: "sessionStorageKey",
+			});
+
+			expect(session).toHaveBeenCalledWith({
+				autoCommit: true,
+				createSessionStorage: expect.any(Function),
+				sessionKey: "sessionKey",
+				sessionStorageKey: "sessionStorageKey",
+			});
+		});
 	});
 
 	describe(cookieSession.name, () => {
@@ -269,6 +291,27 @@ describe("middleware", () => {
 			expect(createCookieSessionStorage).toHaveBeenCalledTimes(1);
 			expect(createCookieSessionStorage).toHaveBeenCalledWith({
 				cookie: { name: "session", secrets: ["s3cr3t"] },
+			});
+		});
+
+		test("forwards sessionKey and sessionStorageKey", async () => {
+			cookieSession<"SECRET">({
+				autoCommit: true,
+				cookie: {
+					name: "session",
+					secrets(c) {
+						return [c.env.SECRET];
+					},
+				},
+				sessionKey: "sessionKey",
+				sessionStorageKey: "sessionStorageKey",
+			});
+
+			expect(session).toHaveBeenCalledWith({
+				autoCommit: true,
+				createSessionStorage: expect.any(Function),
+				sessionKey: "sessionKey",
+				sessionStorageKey: "sessionStorageKey",
 			});
 		});
 	});


### PR DESCRIPTION
For cases like:
```ts
server.use(
  "*",
  cookieSession({
    sessionStorageKey: "session-storage-1",
    sessionKey: "session-1",
    // ...
  }),
  workerKVSession({
    sessionStorageKey: "session-storage-2",
    sessionKey: "session-2",
    // ...
  }),
  remix<ContextEnv>({
    getLoadContext(c) {
      let sessionStorage1 = getSessionStorage(c, "session-storage-1");
      let session1 = getSession(c, "session-1");

      let sessionStorage2 = getSessionStorage(c, "session-storage-2");
      let session2 = getSession(c, "session-2");

      return {
        ...c.env,
        sessionStorage1,
        session1,
        sessionStorage2,
        session2,
      };
    },
    // ...
  })
);
```
