### PR TITLE
Fix redirect not working

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -12,6 +12,6 @@ export function httpsOnly() {
 		}
 
 		url.protocol = "https:";
-		c.redirect(url.toString());
+		return c.redirect(url.toString());
 	});
 }


### PR DESCRIPTION
redirect should be returned or else hono will crash with error `error: context is not finalized. did you forget to return a response object or `await next()``

ref: https://hono.dev/docs/api/context#redirect